### PR TITLE
feat: outputPath option to determine where to render the delta schema

### DIFF
--- a/src/Schemathief.Cli.Testing/DeltaCommandTests.cs
+++ b/src/Schemathief.Cli.Testing/DeltaCommandTests.cs
@@ -30,23 +30,20 @@ internal class DeltaCommandTests
     [Test]
     public async Task Invoke_WithAllRequiredOptions_CallsGenerateAsyncAndReturnsZero()
     {
-        // Arrange
         const string assembly = "path/to/MyLib.dll";
         const string @class = "My.Namespace.MyType";
         const string baseUrl = "https://example.com/schema.json";
         var excludes = new[] { "PropA", "PropB" };
 
         _mockService
-            .Setup(s => s.GenerateAsync(assembly, @class, baseUrl, excludes))
+            .Setup(s => s.GenerateAsync(assembly, @class, baseUrl, excludes, null))
             .ReturnsAsync([])
             .Verifiable();
 
         var args = $"delta -a {assembly} -c {@class} -b {baseUrl} -x PropA|PropB";
 
-        // Act
         var exitCode = await _rootCommand.InvokeAsync(args);
 
-        // Assert
         Assert.That(exitCode, Is.Zero);
         _mockService.Verify();
     }
@@ -54,14 +51,13 @@ internal class DeltaCommandTests
     [Test]
     public async Task Invoke_WithoutExcludeOption_PassesEmptyArrayToService()
     {
-        // Arrange
         const string assembly = "lib.dll";
         const string @class = "C.T";
         const string baseUrl = "http://schema";
         var excludes = new string[0];
 
         _mockService
-            .Setup(s => s.GenerateAsync(assembly, @class, baseUrl, excludes))
+            .Setup(s => s.GenerateAsync(assembly, @class, baseUrl, excludes, null))
             .ReturnsAsync([])
             .Verifiable();
 

--- a/src/Schemathief.Cli.Testing/OutputRendererFactoryTests.cs
+++ b/src/Schemathief.Cli.Testing/OutputRendererFactoryTests.cs
@@ -1,0 +1,47 @@
+using System;
+using NUnit.Framework;
+using Schemathief.Cli.Renderers;
+using Schemathief.Core;
+
+namespace Schemathief.Cli.Testing;
+
+public class OutputRendererFactoryTests
+{
+    private readonly OutputRendererFactory _factory;
+
+    public OutputRendererFactoryTests()
+    {
+        _factory = new OutputRendererFactory();
+    }
+
+    [Test]
+    public void CreateRenderer_WithNullPath_ReturnsConsoleRenderer()
+    {
+        var renderer = _factory.CreateRenderer(null);
+        Assert.That(renderer, Is.TypeOf<ConsoleOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithEmptyPath_ReturnsConsoleRenderer()
+    {
+        var renderer = _factory.CreateRenderer(string.Empty);
+        Assert.That(renderer, Is.TypeOf<ConsoleOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithValidPath_ReturnsFileRenderer()
+    {
+        var path = "test.json";
+        var renderer = _factory.CreateRenderer(path);
+        Assert.That(renderer, Is.TypeOf<FileOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithValidPath_SetsCorrectFilePath()
+    {
+        var path = "test.json";
+        var renderer = _factory.CreateRenderer(path) as FileOutputRenderer;
+        Assert.That(renderer, Is.Not.Null);
+        Assert.That(renderer.FilePath, Is.EqualTo(path));
+    }
+} 

--- a/src/Schemathief.Cli.Testing/RendererIntegrationTests.cs
+++ b/src/Schemathief.Cli.Testing/RendererIntegrationTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Schemathief.Cli.Renderers;
+
+namespace Schemathief.Cli.Testing;
+
+public class RendererIntegrationTests : IDisposable
+{
+    private readonly string _testFilePath;
+    private readonly TextWriter _originalConsoleOut;
+
+    public RendererIntegrationTests()
+    {
+        _testFilePath = Path.GetTempFileName();
+        _originalConsoleOut = Console.Out;
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_testFilePath))
+            File.Delete(_testFilePath);
+        Console.SetOut(_originalConsoleOut);
+    }
+
+    [Test]
+    public async Task ConsoleOutputRenderer_ShouldWriteToConsole()
+    {
+        var renderer = new ConsoleOutputRenderer();
+        var testContent = "Test content";
+        var stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        await renderer.RenderAsync(testContent);
+
+        Assert.That(stringWriter.ToString(), Is.EqualTo(testContent + Environment.NewLine));
+    }
+
+    [Test]
+    public async Task FileOutputRenderer_ShouldWriteToFile()
+    {
+        var renderer = new FileOutputRenderer(_testFilePath);
+        var testContent = "Test content";
+
+        await renderer.RenderAsync(testContent);
+
+        var fileContent = await File.ReadAllTextAsync(_testFilePath);
+        Assert.That(fileContent, Is.EqualTo(testContent));
+    }
+
+    [Test]
+    public async Task FileOutputRenderer_ShouldShowSuccessMessage()
+    {
+        var renderer = new FileOutputRenderer(_testFilePath);
+        var testContent = "Test content";
+        var stringWriter = new StringWriter();
+        Console.SetOut(stringWriter);
+
+        await renderer.RenderAsync(testContent);
+
+        Assert.That(stringWriter.ToString(), Does.Contain($"Schema written to {_testFilePath}"));
+    }
+
+    [Test]
+    public void FileOutputRenderer_WithInvalidPath_ShouldThrowException()
+    {
+        var invalidPath = Path.Combine(Path.GetTempPath(), "nonexistent", "test.json");
+        var renderer = new FileOutputRenderer(invalidPath);
+
+        Assert.That(
+        async () => await renderer.RenderAsync("Test content"),
+        Throws.TypeOf<DirectoryNotFoundException>());
+    }
+} 

--- a/src/Schemathief.Cli/Program.cs
+++ b/src/Schemathief.Cli/Program.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Schemathief.Cli;
 using Schemathief.Core;
+using Schemathief.Core.Renderers;
 using System.Diagnostics.CodeAnalysis;
 using System.CommandLine;
 
@@ -13,7 +14,9 @@ public class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        var deltaService = new DeltaService(new HttpBaseSchemaLoader(new HttpClient()));
+        var deltaService = new DeltaService(
+            new HttpBaseSchemaLoader(new HttpClient()),
+            new OutputRendererFactory());
 
         var rootCommand = new RootCommand("SchemaDelta CLI tool")
             {

--- a/src/Schemathief.Cli/Renderers/ConsoleOutputRenderer.cs
+++ b/src/Schemathief.Cli/Renderers/ConsoleOutputRenderer.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Schemathief.Core;
+
+namespace Schemathief.Cli.Renderers;
+
+public class ConsoleOutputRenderer : IOutputRenderer
+{
+    public Task RenderAsync(string content)
+    {
+        System.Console.WriteLine(content);
+        return Task.CompletedTask;
+    }
+} 

--- a/src/Schemathief.Cli/Renderers/FileOutputRenderer.cs
+++ b/src/Schemathief.Cli/Renderers/FileOutputRenderer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Schemathief.Core;
+
+namespace Schemathief.Cli.Renderers;
+
+public class FileOutputRenderer : IOutputRenderer
+{
+    public string FilePath { get; }
+
+    public FileOutputRenderer(string filePath)
+    {
+        FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+    }
+
+    public async Task RenderAsync(string content)
+    {
+        try
+        {
+            await System.IO.File.WriteAllTextAsync(FilePath, content);
+            System.Console.WriteLine($"Schema written to {FilePath}");
+        }
+        catch (Exception ex)
+        {
+            System.Console.Error.WriteLine($"Error writing to file: {ex.Message}");
+            throw;
+        }
+    }
+} 

--- a/src/Schemathief.Cli/Renderers/OutputRendererFactory.cs
+++ b/src/Schemathief.Cli/Renderers/OutputRendererFactory.cs
@@ -1,0 +1,19 @@
+using System;
+using Schemathief.Core;
+
+namespace Schemathief.Cli.Renderers;
+
+public interface IOutputRendererFactory
+{
+    IOutputRenderer CreateRenderer(string? outputPath);
+}
+
+public class OutputRendererFactory : IOutputRendererFactory
+{
+    public IOutputRenderer CreateRenderer(string? outputPath)
+    {
+        return string.IsNullOrEmpty(outputPath)
+            ? new ConsoleOutputRenderer()
+            : new FileOutputRenderer(outputPath);
+    }
+} 

--- a/src/Schemathief.Core.Testing/BaseSchemaLoaderTests.cs
+++ b/src/Schemathief.Core.Testing/BaseSchemaLoaderTests.cs
@@ -15,7 +15,6 @@ internal class BaseSchemaLoaderTests
     [Test]
     public async Task LoadAsync_ReturnsSchema_WhenPropertiesPresent()
     {
-        // Arrange
         var schemaJson = @"
         {
           ""title"": ""MySchema"",
@@ -33,10 +32,8 @@ internal class BaseSchemaLoaderTests
         var client = mockHttp.ToHttpClient();
         var loader = new HttpBaseSchemaLoader(client);
 
-        // Act
-        JsonObject? result = await loader.LoadAsync("https://example.com/schema.json");
+        var result = await loader.LoadAsync("https://example.com/schema.json");
 
-        // Assert
         Assert.That(result, Is.Not.Null);
         var props = result["properties"]!.AsObject().Select(p => p.Key).ToHashSet();
         Assert.That(props.Contains("Foo"));
@@ -46,7 +43,6 @@ internal class BaseSchemaLoaderTests
     [Test]
     public async Task LoadAsync_ReturnsNull_WhenPropertiesMissing()
     {
-        // Arrange
         var noPropsJson = @"{ ""title"": ""EmptySchema"" }";
 
         var mockHttp = new MockHttpMessageHandler();
@@ -57,7 +53,7 @@ internal class BaseSchemaLoaderTests
         var client = mockHttp.ToHttpClient();
         var loader = new HttpBaseSchemaLoader(client);
 
-        JsonObject? result = await loader.LoadAsync("https://example.com/no-props.json");
+        var result = await loader.LoadAsync("https://example.com/no-props.json");
 
         Assert.That(result, Is.Null);
     }

--- a/src/Schemathief.Core.Testing/DeltaServiceTests.cs
+++ b/src/Schemathief.Core.Testing/DeltaServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -121,7 +121,6 @@ internal class DeltaServiceTests
     [Test]
     public async Task GenerateAsync_WithOutputPath_CreatesAndUsesFileRenderer()
     {
-        
         string url = "https://example.com/schema-partial.json";
         string schemaJson = @"{
                 'title': 'Test',

--- a/src/Schemathief.Core.Testing/DeltaServiceTests.cs
+++ b/src/Schemathief.Core.Testing/DeltaServiceTests.cs
@@ -6,16 +6,19 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using RichardSzalay.MockHttp;
+using Moq;
+using Schemathief.Core.Renderers;
 
 namespace Schemathief.Core.Testing;
 internal class DeltaServiceTests
 {
-    private MockHttpMessageHandler _mockHttp;
-    private HttpClient _httpClient;
-    private HttpBaseSchemaLoader _loader;
-    private DeltaService _service;
-    private string _assemblyPath;
-    private string _validTypeName;
+    private MockHttpMessageHandler _mockHttp = null!;
+    private HttpClient _httpClient = null!;
+    private HttpBaseSchemaLoader _loader = null!;
+    private Mock<IOutputRendererFactory> _rendererFactoryMock = null!;
+    private DeltaService _service = null!;
+    private string _assemblyPath = null!;
+    private string _validTypeName = null!;
 
     [SetUp]
     public void SetUp()
@@ -28,7 +31,8 @@ internal class DeltaServiceTests
         _mockHttp = new MockHttpMessageHandler();
         _httpClient = _mockHttp.ToHttpClient();
         _loader = new HttpBaseSchemaLoader(_httpClient);
-        _service = new DeltaService(_loader);
+        _rendererFactoryMock = new Mock<IOutputRendererFactory>();
+        _service = new DeltaService(_loader, _rendererFactoryMock.Object);
     }
 
     [TearDown]
@@ -99,6 +103,10 @@ internal class DeltaServiceTests
 
         _mockHttp.When(url).Respond("application/json", schemaJson);
 
+        var mockRenderer = new Mock<IOutputRenderer>();
+        _rendererFactoryMock.Setup(f => f.CreateRenderer(It.IsAny<string>()))
+            .Returns(mockRenderer.Object);
+
         var result = await _service.GenerateAsync(_assemblyPath, _validTypeName, url, Array.Empty<string>());
 
         Assert.That(result, Is.Not.Null, "Expected delta schema when new properties exist");
@@ -108,5 +116,53 @@ internal class DeltaServiceTests
         var props = allOf[1]!["properties"]!.AsObject();
         Assert.That(props.ContainsKey("age"), Is.True);
         Assert.That(props["age"]!["type"]!.ToString(), Is.EqualTo("integer"));
+    }
+
+    [Test]
+    public async Task GenerateAsync_WithOutputPath_CreatesAndUsesFileRenderer()
+    {
+        // Arrange
+        string url = "https://example.com/schema-partial.json";
+        string schemaJson = @"{
+                'title': 'Test',
+                'properties': { 'name': { 'type': 'string' } }
+            }".Replace('\'', '"');
+
+        _mockHttp.When(url).Respond("application/json", schemaJson);
+
+        var mockRenderer = new Mock<IOutputRenderer>();
+        _rendererFactoryMock.Setup(f => f.CreateRenderer(It.IsAny<string>()))
+            .Returns(mockRenderer.Object);
+
+        // Act
+        await _service.GenerateAsync(_assemblyPath, _validTypeName, url, Array.Empty<string>(), "test.json");
+
+        // Assert
+        _rendererFactoryMock.Verify(f => f.CreateRenderer("test.json"), Times.Once);
+        mockRenderer.Verify(r => r.RenderAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GenerateAsync_WithoutOutputPath_CreatesAndUsesConsoleRenderer()
+    {
+        // Arrange
+        string url = "https://example.com/schema-partial.json";
+        string schemaJson = @"{
+                'title': 'Test',
+                'properties': { 'name': { 'type': 'string' } }
+            }".Replace('\'', '"');
+
+        _mockHttp.When(url).Respond("application/json", schemaJson);
+
+        var mockRenderer = new Mock<IOutputRenderer>();
+        _rendererFactoryMock.Setup(f => f.CreateRenderer(null))
+            .Returns(mockRenderer.Object);
+
+        // Act
+        await _service.GenerateAsync(_assemblyPath, _validTypeName, url, Array.Empty<string>());
+
+        // Assert
+        _rendererFactoryMock.Verify(f => f.CreateRenderer(null), Times.Once);
+        mockRenderer.Verify(r => r.RenderAsync(It.IsAny<string>()), Times.Once);
     }
 }

--- a/src/Schemathief.Core.Testing/DeltaServiceTests.cs
+++ b/src/Schemathief.Core.Testing/DeltaServiceTests.cs
@@ -121,7 +121,7 @@ internal class DeltaServiceTests
     [Test]
     public async Task GenerateAsync_WithOutputPath_CreatesAndUsesFileRenderer()
     {
-        // Arrange
+        
         string url = "https://example.com/schema-partial.json";
         string schemaJson = @"{
                 'title': 'Test',
@@ -134,10 +134,8 @@ internal class DeltaServiceTests
         _rendererFactoryMock.Setup(f => f.CreateRenderer(It.IsAny<string>()))
             .Returns(mockRenderer.Object);
 
-        // Act
         await _service.GenerateAsync(_assemblyPath, _validTypeName, url, Array.Empty<string>(), "test.json");
 
-        // Assert
         _rendererFactoryMock.Verify(f => f.CreateRenderer("test.json"), Times.Once);
         mockRenderer.Verify(r => r.RenderAsync(It.IsAny<string>()), Times.Once);
     }
@@ -145,7 +143,6 @@ internal class DeltaServiceTests
     [Test]
     public async Task GenerateAsync_WithoutOutputPath_CreatesAndUsesConsoleRenderer()
     {
-        // Arrange
         string url = "https://example.com/schema-partial.json";
         string schemaJson = @"{
                 'title': 'Test',
@@ -158,10 +155,8 @@ internal class DeltaServiceTests
         _rendererFactoryMock.Setup(f => f.CreateRenderer(null))
             .Returns(mockRenderer.Object);
 
-        // Act
         await _service.GenerateAsync(_assemblyPath, _validTypeName, url, Array.Empty<string>());
 
-        // Assert
         _rendererFactoryMock.Verify(f => f.CreateRenderer(null), Times.Once);
         mockRenderer.Verify(r => r.RenderAsync(It.IsAny<string>()), Times.Once);
     }

--- a/src/Schemathief.Core.Testing/Renderers/OutputRendererFactoryTests.cs
+++ b/src/Schemathief.Core.Testing/Renderers/OutputRendererFactoryTests.cs
@@ -23,67 +23,47 @@ public class OutputRendererFactoryTests
     public void TearDown()
     {
         if (Directory.Exists(_tempDirectory))
-        {
             Directory.Delete(_tempDirectory, true);
-        }
     }
 
     [Test]
     public void CreateRenderer_WithNullPath_ReturnsConsoleRenderer()
     {
-        // Act
         var renderer = _factory.CreateRenderer(null);
-
-        // Assert
         Assert.That(renderer, Is.InstanceOf<ConsoleOutputRenderer>());
     }
 
     [Test]
     public void CreateRenderer_WithEmptyPath_ReturnsConsoleRenderer()
     {
-        // Act
         var renderer = _factory.CreateRenderer(string.Empty);
-
-        // Assert
         Assert.That(renderer, Is.InstanceOf<ConsoleOutputRenderer>());
     }
 
     [Test]
     public void CreateRenderer_WithValidRelativePath_ReturnsFileRenderer()
     {
-        // Arrange
         var path = "test.json";
 
-        // Act
         var renderer = _factory.CreateRenderer(path);
-
-        // Assert
         Assert.That(renderer, Is.InstanceOf<FileOutputRenderer>());
     }
 
     [Test]
     public void CreateRenderer_WithValidAbsolutePath_ReturnsFileRenderer()
     {
-        // Arrange
         var path = Path.Combine(_tempDirectory, "test.json");
 
-        // Act
         var renderer = _factory.CreateRenderer(path);
-
-        // Assert
         Assert.That(renderer, Is.InstanceOf<FileOutputRenderer>());
     }
 
     [Test]
     public void CreateRenderer_WithValidPath_SetsCorrectFilePath()
     {
-        // Arrange
         var path = Path.Combine(_tempDirectory, "test.json");
 
-        // Act
         var renderer = _factory.CreateRenderer(path) as FileOutputRenderer;
-
-        // Assert
         Assert.That(renderer, Is.Not.Null);
         Assert.That(renderer!.FilePath, Is.EqualTo(Path.GetFullPath(path)));
     }
@@ -91,24 +71,17 @@ public class OutputRendererFactoryTests
     [Test]
     public void CreateRenderer_WithValidPath_CreatesDirectoryIfNotExists()
     {
-        // Arrange
         var subDir = Path.Combine(_tempDirectory, "subdir");
         var path = Path.Combine(subDir, "test.json");
 
-        // Act
         _factory.CreateRenderer(path);
-
-        // Assert
         Assert.That(Directory.Exists(subDir), Is.True);
     }
 
     [Test]
     public void CreateRenderer_WithInvalidPath_ThrowsArgumentException()
     {
-        // Arrange
         var invalidPath = "test:invalid.json";
-
-        // Act & Assert
         Assert.That(() => _factory.CreateRenderer(invalidPath),
             Throws.ArgumentException.With.Message.Contains("Invalid output path"));
     }
@@ -116,10 +89,7 @@ public class OutputRendererFactoryTests
     [Test]
     public void CreateRenderer_WithInvalidCharacters_ThrowsArgumentException()
     {
-        // Arrange
         var invalidPath = "test<>.json";
-
-        // Act & Assert
         Assert.That(() => _factory.CreateRenderer(invalidPath),
             Throws.ArgumentException.With.Message.Contains("Invalid output path"));
     }

--- a/src/Schemathief.Core.Testing/Renderers/OutputRendererFactoryTests.cs
+++ b/src/Schemathief.Core.Testing/Renderers/OutputRendererFactoryTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Schemathief.Core.Renderers;
+
+namespace Schemathief.Core.Testing.Renderers;
+
+[TestFixture]
+public class OutputRendererFactoryTests
+{
+    private OutputRendererFactory _factory = null!;
+    private string _tempDirectory = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _factory = new OutputRendererFactory();
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "SchemathiefTests");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Test]
+    public void CreateRenderer_WithNullPath_ReturnsConsoleRenderer()
+    {
+        // Act
+        var renderer = _factory.CreateRenderer(null);
+
+        // Assert
+        Assert.That(renderer, Is.InstanceOf<ConsoleOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithEmptyPath_ReturnsConsoleRenderer()
+    {
+        // Act
+        var renderer = _factory.CreateRenderer(string.Empty);
+
+        // Assert
+        Assert.That(renderer, Is.InstanceOf<ConsoleOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithValidRelativePath_ReturnsFileRenderer()
+    {
+        // Arrange
+        var path = "test.json";
+
+        // Act
+        var renderer = _factory.CreateRenderer(path);
+
+        // Assert
+        Assert.That(renderer, Is.InstanceOf<FileOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithValidAbsolutePath_ReturnsFileRenderer()
+    {
+        // Arrange
+        var path = Path.Combine(_tempDirectory, "test.json");
+
+        // Act
+        var renderer = _factory.CreateRenderer(path);
+
+        // Assert
+        Assert.That(renderer, Is.InstanceOf<FileOutputRenderer>());
+    }
+
+    [Test]
+    public void CreateRenderer_WithValidPath_SetsCorrectFilePath()
+    {
+        // Arrange
+        var path = Path.Combine(_tempDirectory, "test.json");
+
+        // Act
+        var renderer = _factory.CreateRenderer(path) as FileOutputRenderer;
+
+        // Assert
+        Assert.That(renderer, Is.Not.Null);
+        Assert.That(renderer!.FilePath, Is.EqualTo(Path.GetFullPath(path)));
+    }
+
+    [Test]
+    public void CreateRenderer_WithValidPath_CreatesDirectoryIfNotExists()
+    {
+        // Arrange
+        var subDir = Path.Combine(_tempDirectory, "subdir");
+        var path = Path.Combine(subDir, "test.json");
+
+        // Act
+        _factory.CreateRenderer(path);
+
+        // Assert
+        Assert.That(Directory.Exists(subDir), Is.True);
+    }
+
+    [Test]
+    public void CreateRenderer_WithInvalidPath_ThrowsArgumentException()
+    {
+        // Arrange
+        var invalidPath = "test:invalid.json";
+
+        // Act & Assert
+        Assert.That(() => _factory.CreateRenderer(invalidPath),
+            Throws.ArgumentException.With.Message.Contains("Invalid output path"));
+    }
+
+    [Test]
+    public void CreateRenderer_WithInvalidCharacters_ThrowsArgumentException()
+    {
+        // Arrange
+        var invalidPath = "test<>.json";
+
+        // Act & Assert
+        Assert.That(() => _factory.CreateRenderer(invalidPath),
+            Throws.ArgumentException.With.Message.Contains("Invalid output path"));
+    }
+} 

--- a/src/Schemathief.Core.Testing/Renderers/RendererIntegrationTests.cs
+++ b/src/Schemathief.Core.Testing/Renderers/RendererIntegrationTests.cs
@@ -37,30 +37,24 @@ public class RendererIntegrationTests : IDisposable
     [Test]
     public async Task ConsoleOutputRenderer_ShouldWriteToConsole()
     {
-        // Arrange
         var renderer = new ConsoleOutputRenderer();
         var testContent = "Test content";
         var stringWriter = new StringWriter();
         Console.SetOut(stringWriter);
 
-        // Act
         await renderer.RenderAsync(testContent);
 
-        // Assert
         Assert.That(stringWriter.ToString(), Is.EqualTo(testContent + Environment.NewLine));
     }
 
     [Test]
     public async Task FileOutputRenderer_ShouldWriteToFile()
     {
-        // Arrange
         var renderer = new FileOutputRenderer(_testFilePath);
         var testContent = "Test content";
 
-        // Act
         await renderer.RenderAsync(testContent);
 
-        // Assert
         var fileContent = await File.ReadAllTextAsync(_testFilePath);
         Assert.That(fileContent, Is.EqualTo(testContent));
     }
@@ -68,27 +62,21 @@ public class RendererIntegrationTests : IDisposable
     [Test]
     public async Task FileOutputRenderer_ShouldShowSuccessMessage()
     {
-        // Arrange
         var renderer = new FileOutputRenderer(_testFilePath);
         var testContent = "Test content";
         var stringWriter = new StringWriter();
         Console.SetOut(stringWriter);
 
-        // Act
         await renderer.RenderAsync(testContent);
 
-        // Assert
         Assert.That(stringWriter.ToString(), Does.Contain($"Schema written to {_testFilePath}"));
     }
 
     [Test]
     public void FileOutputRenderer_WithInvalidPath_ShouldThrowException()
     {
-        // Arrange
         var invalidPath = Path.Combine(Path.GetTempPath(), "nonexistent", "test.json");
         var renderer = new FileOutputRenderer(invalidPath);
-
-        // Act & Assert
         Assert.That(async () => await renderer.RenderAsync("Test content"),
             Throws.TypeOf<DirectoryNotFoundException>());
     }

--- a/src/Schemathief.Core.Testing/SchemaDeltaBuilderTests.cs
+++ b/src/Schemathief.Core.Testing/SchemaDeltaBuilderTests.cs
@@ -26,7 +26,6 @@ internal class SchemaDeltaBuilderTests
     [Test]
     public void BuildDeltaProperties_ExcludesBaseProps_AndGeneratesCorrectSchemaEntries()
     {
-        // Arrange
         var definedProps = typeof(DummyType)
             .GetProperties(BindingFlags.Public | BindingFlags.Instance)
             .ToHashSet();
@@ -34,7 +33,6 @@ internal class SchemaDeltaBuilderTests
         // Exclude "Count" so that nullable int property is treated as base
         var baseProps = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Count" };
 
-        // Act
         var delta = SchemaDeltaBuilder.BuildDeltaProperties(definedProps, baseProps);
 
         // Assert keys: Name, Values, Details (camelCase)
@@ -63,7 +61,6 @@ internal class SchemaDeltaBuilderTests
     [Test]
     public void BuildFinalSchema_CombinesBaseAndDelta_WithCorrectStructure()
     {
-        // Arrange
         var baseSchema = new JsonObject
         {
             ["title"] = "Original"

--- a/src/Schemathief.Core/IDeltaService.cs
+++ b/src/Schemathief.Core/IDeltaService.cs
@@ -12,5 +12,6 @@ public interface IDeltaService
         string assemblyPath,
         string fullyQualifiedClassName,
         string baseSchemaUrl,
-        string[] excludes);
+        string[] excludes,
+        string? outputPath);
 }

--- a/src/Schemathief.Core/IOutputRenderer.cs
+++ b/src/Schemathief.Core/IOutputRenderer.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace Schemathief.Core;
+
+public interface IOutputRenderer
+{
+    Task RenderAsync(string content);
+} 

--- a/src/Schemathief.Core/Renderers/ConsoleOutputRenderer.cs
+++ b/src/Schemathief.Core/Renderers/ConsoleOutputRenderer.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace Schemathief.Core.Renderers;
+
+public class ConsoleOutputRenderer : IOutputRenderer
+{
+    public Task RenderAsync(string content)
+    {
+        System.Console.WriteLine(content);
+        return Task.CompletedTask;
+    }
+} 

--- a/src/Schemathief.Core/Renderers/FileOutputRenderer.cs
+++ b/src/Schemathief.Core/Renderers/FileOutputRenderer.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Schemathief.Core.Renderers;
+
+public class FileOutputRenderer : IOutputRenderer
+{
+    public string FilePath { get; }
+
+    public FileOutputRenderer(string filePath)
+    {
+        FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+    }
+
+    public async Task RenderAsync(string content)
+    {
+        try
+        {
+            await System.IO.File.WriteAllTextAsync(FilePath, content);
+            System.Console.WriteLine($"Schema written to {FilePath}");
+        }
+        catch (Exception ex)
+        {
+            System.Console.Error.WriteLine($"Error writing to file: {ex.Message}");
+            throw;
+        }
+    }
+} 

--- a/src/Schemathief.Core/Renderers/OutputRendererFactory.cs
+++ b/src/Schemathief.Core/Renderers/OutputRendererFactory.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Schemathief.Core.Renderers;
+
+public interface IOutputRendererFactory
+{
+    IOutputRenderer CreateRenderer(string? outputPath);
+}
+
+public class OutputRendererFactory : IOutputRendererFactory
+{
+    public IOutputRenderer CreateRenderer(string? outputPath)
+    {
+        if (string.IsNullOrEmpty(outputPath))
+            return new ConsoleOutputRenderer();
+
+        try
+        {
+            var filename = Path.GetFileName(outputPath);
+            if (string.IsNullOrEmpty(filename) || filename.Any(x => Path.GetInvalidFileNameChars().Contains(x)))
+                throw new ArgumentException($"Invalid output path: {outputPath}. The path must be a valid relative or absolute path.", nameof(outputPath));
+
+            var fullPath = Path.GetFullPath(outputPath);
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directory) && directory.Any(x => Path.GetInvalidPathChars().Contains(x)))
+                throw new ArgumentException($"Invalid output path: {outputPath}. The path must be a valid relative or absolute path.", nameof(outputPath));
+
+            // Ensure the directory exists or can be created
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            return new FileOutputRenderer(fullPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException)
+        {
+            throw new ArgumentException($"Invalid output path: {outputPath}. The path must be a valid relative or absolute path.", nameof(outputPath), ex);
+        }
+    }
+} 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an `--output` (`-o`) option to write command output to a specified file or the console.
  - Introduced flexible output rendering with new components for console and file output.
- **Bug Fixes**
  - Improved error handling for invalid output file paths.
- **Tests**
  - Added and enhanced unit and integration tests for output rendering functionality, including file and console scenarios.
- **Chores**
  - Minor test code cleanup and refactoring for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->