### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,45 @@
 
 ![Logo](https://raw.githubusercontent.com/Seddryck/Schemathief/main/assets/schemathief-logo-256.png)
 
-Transform your structured YAML, JSON, XML, CSV or FrontMatter data into beautiful, fully-customized HTML pages or plain text in seconds with Schemathief. This command-line tool seamlessly generates renders from data files using your preferred templates through Scriban, Handlebars, DotLiquid, Fluid, StringTemplate or SmartFormat. Whether you're building static sites, documentation, or reporting tools, Schemathief makes it easy to turn raw data into polished, web-ready content.
+Schemathief is a lightweight .NET library and CLI tool for generating JSON-Schema delta documents from your CLR types. Whether you need to keep your API schema up-to-date, drive automated data-model documentation, or generate client stubs only for the new fields you’ve added, Schemathief does the heavy lifting:
+
+1. Load & compare
+
+Fetches a base schema from a URL or file via a pluggable IBaseSchemaLoader
+
+Reflects over your target assembly to discover all public, read/write properties
+
+Allows you to exclude known fields (e.g. legacy or deprecated properties)
+
+1. Generate delta
+
+Maps .NET types to JSON-Schema types (string, integer, array, object) with full support for nullable, primitive, and complex types
+
+Recursively builds nested definitions for child objects and collections
+
+Produces a minimal “delta schema” that you can combine with your base via an allOf merge
+
+1. CLI & API
+
+A dotnet tool–friendly System.CommandLine implementation (delta verb, intuitive options) ready for CI/CD
+
+Dependency-injection–friendly services (IDeltaService, IBaseSchemaLoader) so you can stub or replace behavior in your own apps
+
+Fully unit‐tested core (SchemaBuilder, TypeInspector, ClrToJsonTypeMapper, TypeInspectorHelper) and integration‐tested end-to-end
+
+1. Pack & ship
+
+Ship your own JSON-Schema artifacts right inside your NuGet package via contentFiles/any/any/schemas so consumers get editor IntelliSense out of the box
+
+Integrates smoothly into existing build pipelines with dotnet pack, GitVersion, or any other automation
+
+# Why Schemathief?
+
+Zero boilerplate: No more hand-crafting schema diffs by hand or writing reflection glue in every project.
+
+Future-proof: Designed around the JSON-Schema draft-07 spec today, easy to extend for draft-next tomorrow.
+
+Give it a try in your next microservice or data-model repo—keep your schemas in lock-step with your code
 
 [About][] | [Installing][] | [Quickstart][]
 
@@ -22,10 +60,10 @@ Transform your structured YAML, JSON, XML, CSV or FrontMatter data into beautifu
 ![Still maintained](https://img.shields.io/maintenance/yes/2025.svg)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Seddryck/Schemathief)
 
-**Continuous integration builds:** [![Build status](https://ci.appveyor.com/api/projects/status/na3dklqjsuv1lbfv?svg=true)](https://ci.appveyor.com/project/Seddryck/Schemathief/)
+**Continuous integration builds:** [![Build status](https://ci.appveyor.com/api/projects/status/srnux32j07ysvsp1?svg=true)](https://ci.appveyor.com/project/Seddryck/Schemathief/)
 [![Tests](https://img.shields.io/appveyor/tests/seddryck/Schemathief.svg)](https://ci.appveyor.com/project/Seddryck/Schemathief/build/tests)
 [![CodeFactor](https://www.codefactor.io/repository/github/seddryck/Schemathief/badge)](https://www.codefactor.io/repository/github/seddryck/Schemathief)
-[![codecov](https://codecov.io/github/Seddryck/Schemathief/branch/main/graph/badge.svg?token=YRA8IRIJYV)](https://codecov.io/github/Seddryck/Schemathief)
+[![codecov](https://codecov.io/github/Seddryck/Schemathief/branch/main/graph/badge.svg?token=76Q2XAL4J7)](https://codecov.io/github/Seddryck/Schemathief)
 <!-- [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FSeddryck%2FSchemathief.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FSeddryck%2FSchemathief?ref=badge_shield) -->
 
 **Status:** [![stars badge](https://img.shields.io/github/stars/Seddryck/Schemathief.svg)](https://github.com/Seddryck/Schemathief/stargazers)
@@ -73,285 +111,54 @@ To update a globally installed .NET tool, use the dotnet tool update command:
 dotnet tool update -g Schemathief-cli
 ```
 
-### Install from Docker
+## Quickstart
 
-#### Prerequisites
+### `delta` Command – Generate a JSON Schema Delta
 
-**Docker Installed**: Ensure that Docker is installed and running on your system. You can download Docker from Docker's official site.
+Generates a **delta JSON Schema** from a .NET type by comparing it against a base schema. This is useful when evolving data models incrementally, and you want to isolate new or changed fields.
 
-#### Pulling the Docker Image
-
-A pre-built Docker image is available on Docker Hub, you can pull it using the following command:
-
-```powershell
-docker pull seddryck/schemathief:latest
-```
-
-#### Running Schemathief from Docker
-
-Once you have the Docker image, you can run Schemathief using Docker in PowerShell.
-
-###### Basic Command
-
-<sub>CMD:</sub>
-```CMD
-docker run --rm -v %cd%:/files schemathief -t <template-file> -s <source-file> -o <output-file>
-```
-
-<sub>PowerShell:</sub>
-```powershell
-docker run --rm -v ${pwd}:/files schemathief -t <template-file> -s <source-file> -o <output-file>
-```
-
-- `--rm`: Automatically removes the container after it finishes executing.
-- `-v ${pwd}:/files`: Mounts the current directory (`${pwd}` in PowerShell or Bash, `%cd%` in CMD) to /files inside the Docker container, so Schemathief can access your local files.
-- `-t <template-file>`: Specifies the path to the template file inside the /files directory.
-- `-s <source-file>`: Specifies the path to the source file (YAML, JSON, or XML).
-- `-o <output-file>`: Specifies the path to the output file that Schemathief will generate. If omitted, it will display the result on the host console.
-
-##### Example Workflow:
-
-1. Prepare the Template and Source Files:
-
-  - Make sure your template and source files are correctly formatted and saved in the correct directory. For example:
-    - `./templates/template-01.hbs`
-    - `./data/data.json`
-2. Run Schemathief: Use the following command to generate templated output:
-
-```powershell
-docker run --rm -v ${pwd}:/files schemathief -t /files/templates/template-01.hbs -s /files/data/data.json -o /files/output/output.txt
-```
-
-3. Access the Output: The output file will be generated in ./output/output.txt on your local machine after the Docker container finishes execution.
-
-#### Updating Schemathief
-
-To update to the latest version of Schemathief, either pull the new Docker image
-
-```powershell
-docker pull seddryck/schemathief:latest
-```
-
-### Install from GitHub Releases
-
-#### Step 1: Download the ZIP from the GitHub Release
-
-1. Navigate to the **GitHub repository** of the project.
-2. Go to the **Releases** section, usually found under the "Code" tab.
-3. Download the `.zip` file containing the executable from the desired release.
-
-Example:
-
-   ```
-   https://github.com/Seddryck/Schemathief/releases/latest/
-   ```
-
-#### Step 2: Extract the ZIP File
-
-1. Right-click the downloaded `.zip` file and choose **Extract All**.
-2. Extract the contents to a directory of your choice, such as `C:\Program Files\Schemathief`.
-
-> **Tip**: Choose a path that is easy to remember and doesn't contain special characters.
-
-#### Step 3: Add the Executable to the System PATH
-
-To run the executable from any location in the command line, you need to add its folder to your system's PATH.
-
-1. Open the **Start Menu** and search for **Environment Variables**.
-2. Click **Edit the system environment variables**.
-3. In the **System Properties** window, click **Environment Variables**.
-4. In the **System Variables** section, scroll down, select **Path**, and click **Edit**.
-5. In the **Edit Environment Variable** dialog, click **New** and enter the path to your extracted folder, e.g., `C:\Program Files\Schemathief`.
-6. Click **OK** to close all windows.
-
-### Step 4: Verify Installation
-
-1. Open **Command Prompt** (CMD).
-2. Type the name of the executable (e.g., `schemathief.exe`) and hit Enter.
-3. If everything is set up correctly, the program should run.
-
-## QuickStart
-
-**Schemathief** is a command-line tool designed for generating files based on templating. It supports *YAML*, *JSON*, and *XML* as source data formats and provides flexibility in templating through both *Scriban*, *Liquid*, *Handlebars*, *StringTemplate* and *SmartFormat* templates languages. With Schemathief, you can easily automate file generation by combining structured data from YAML, JSON, or XML files with customizable templates using Scriban or Liquid.
-
-### Supported Data Formats:
-
-- **YAML**: Files with the `.yaml` or `.yml` extension are parsed using a YAML source parser.
-- **JSON**: Files with the `.json` extension are parsed using a JSON source parser.
-- **XML**: Files with the `.xml` extension are parsed using an XML source parser.
-- **CSV**: Files with the `.csv` extension are parsed using an CSV source parser. The CSV dialect can be described using the `-P` option (see below).
-- **FrontMatterMarkdown**: Files with the `.md` extension are parsed using an YAML parser for the FrontMatter and the Markdown content is added in the entry *content*.
-- **FrontMatter**: using an YAML parser for the FrontMatter, the Markdown content is not appended to the result.
-
-### Supported Templating Engines:
-
-Schemathief utilizes some templating engines, which allow for powerful and flexible templating.
-
-- **Scriban**: Templates with the `.scriban` extension are parsed using a Scriban template engine. Scriban is a lightweight and fast template engine with rich support for multiple output formats.
-  - Highly performant, designed to handle large-scale template processing.
-  - Supports customizable scripting with rich expressions and filters.
-  - Can work with JSON and YAML data sources.
-  - Typical Use Case: Config file generation, reports, email templates, or any templating scenario not tied to a specific web framework.
-- **Liquid**: Templates with the `.liquid` extension are parsed using a dotLiquid template engine. DotLiquid is a .NET port of the Liquid templating engine used by platforms like Shopify.
-  - Secure (no access to system objects), making it ideal for user-generated templates.
-  - Allows both dynamic and static templating.
-  - Supports filters, tags, and various control flow structures.
-  - Typical Use Case: SaaS applications, dynamic content rendering, email templates.
-- **Handlebars**: Templates with the `.hbs` extension are parsed using a Handlebars template engine. Handlebars C# port of the popular JavaScript Handlebars templating engine.
-  - Simple syntax for generating HTML or text files from templates.
-  - Support for helpers, partial templates, and block helpers.
-  - Good separation of logic from presentation.
-  - Typical Use Case: Email templates, reports, and content generation.
-- **SmartFormat**: Templates with the `.smart` extension are parsed using a SmartFormat template engine. SmartFormat.Net is a A lightweight templating engine primarily used for string formatting.
-  - Provides more advanced formatting capabilities than standard string formatting in C#.
-  - Supports nested templates, conditional formatting, and more.
-  - Typical Use Case: Log messages, report generation, and dynamic text formatting.
-- **StringTemplate**: Templates with the `.st` and `.stg` extension are parsed using the StringTemplate engine. StringTemplate is a powerful template engine specifically designed to enforce strict separation of logic from presentation.
-  - Focused on generating structured text, such as code, XML, and reports.
-  - Strong emphasis on enforcing Model-View separation.
-  - Supports conditionals, loops, and automatic escaping to prevent security issues.
-  - Typical Use Case: Code generation, configuration files, and situations where strict separation between logic and template is required.
-
-### Command Usage:
-
-The command to run Schemathief is simply `schemathief`. When executing it, you need to provide three required arguments:
-
-- `-t, --template` (required): Specifies the path to the Scriban, Liquid, Handlebars, StringTemplate or SmartFormat template file.
-- `-s, --source`: Specifies the path to the source data file, which can be in YAML, JSON, or XML format. If this argument is not provided, the data will be read from the console input. In such cases, the `-r, --parser` option becomes mandatory.
-- `-o, --output`: Specifies the path to the output file where the generated content will be saved. If not provided, the output will be displayed directly in the console.
-
-**Example:**
+#### Usage
 
 ```bash
-schemathief -t template.scriban -s data.yaml -o page.html
+schemathief delta --assembly <path> --class <fqcn> --base <url> [--exclude <a|b>] [--output <file>]
 ```
 
-In this example:
-
-- `template.scriban` is the Scriban template file.
-- `data.yaml` is the source file containing the structured data in YAML format.
-- `page.html` is the output file that will contain the generated content.
-
-### List of options
-
-### Template option
-
-- Shortcut: `-t`
-- Long: `--template`
-- Description: Specifies the path to the template file.
-- Accept: single value.
-- Mandatory: yes.
-- Example: `-t path/to/template` or `--template=path/to/template`
-
-### Engine option
-
-- Shortcut: `-e`
-- Long: `--engine`
-- Description: Specifies the template engine to use (scriban, fluid, dotliquid, handlebars, smartformat, stringtemplate).
-- Accept: single value. When omitted Schemathief will select the engine based on the extension of the template file.
-- Example: `-e fluid` or `--engine=fluid`
-
-### Engine files' extension association option
-
-- Shortcut: `-x`
-- Long: `--engine-extension`
-- Description: Specifies additional or replacing association between a file extension and an engine for automatic detection
-- Accept: multiple key-value pairs.
-- Mandatory: no.
-- Example: `-x txt:handlebars;liquid:fluid` or `--engine-extension=.txt:handlebars;liquid:fluid`
-
-### Source option
-
-- Shortcut: `-s`
-- Long: `--source`
-- Accept: single value or multiple key-value pairs.
-- Description:
-  - if single value is provided, it specifies the path to the source file. If omitted, input can be taken from StdIn.
-  - if multiple key-value pairs are provided, each of them specifies a part of the model and the key representing the tag in the model.
-- Exclusive: can't be set with the parameter `--StdIn`
-- Example: `-s path/to/source` or `--source=path/to/source` or `--source=foo:path/to/source1;bar:path/to/source1`
-
-### Parser option
-
-- Shortcut: `-r`
-- Long: `--parser`
-- Description: Specifies the parser to use (YAML, JSON, XML).
-- Accept: single value.
-- Mandatory: no expect if `--stdin` is specified. When omitted Schemathief will select the parser based on the extension of the source file
-- Example: `-r YAML` or `--parser=YAML`
-
-### Parser files' extension association option
-
-- Shortcut: `-X`
-- Long: `--parser-extension`
-- Description: Specifies additional or replacing association between a file extension and a parser for automatic detection
-- Accept: multiple key-value pairs.
-- Mandatory: no.
-- Example: `-X txt:yaml;dat:json` or `--parser-extension=txt:yaml;dat:json`
-
-### Parser's parameter option
-
-- Shortcut: `-P`
-- Long: `--parser-parameter`
-- Description: Specifies parameters tuning the behavior of the parser
-- Accept: multiple key-value pairs, prefixed by the file's extension followed by an arobas (`@`).
-- Mandatory: no.
-- Example: `-P csv@delimiter=^;csv@commentChar=#`
-
-### StdIn option
-
-- Shortcut: `-i`
-- Long: `--stdin`
-- Description: Specifies the input to the source data as coming from the StdIn.
-- Accept: switch value.
-- Exclusive: can't be set to true with the parameter `--source` and must specified to false when `--source` is not provided.
-- Example: `-i` or `--stdin` or `--stdin false`
-
-### Output option
-
-- Shortcut: `-o`
-- Long: `--output`
-- Description: Specifies the path to the generated output file. If omitted, output is rendered to StdOut.
-- Accept: single value.
-- Mandatory: no.
-- Example: `-o path/to/output` or `--output=path/to/output`
-
-#### Example:
-
-##### With a source file:
+You can also use short options:
 
 ```bash
-schemathief -t template.scriban -s data.yaml -o page.html
+schemathief delta -a MyLib.dll -c My.Namespace.Type -b https://schemas/base.json -x Id|Timestamp -o delta.json
 ```
 
-In this example:
+#### Options
 
-- `template.scriban` is the Scriban template file.
-- `data.yaml` is the source file containing the structured data in YAML format.
-- `page.html` is the output file that will contain the generated content.
+| Option            | Aliases         | Required | Description |
+|-------------------|------------------|----------|-------------|
+| `--assembly`      | `-a`             | ✅ Yes   | Path to the compiled `.dll` file containing the class. |
+| `--class`         | `-c`             | ✅ Yes   | Fully qualified name of the target .NET class (e.g. `MyApp.Models.Customer`). |
+| `--base`          | `-b`             | ✅ Yes   | URL or file path to the base JSON Schema you want to extend. |
+| `--exclude`       | `-x`             | No       | Pipe-separated list of properties to ignore in the delta (e.g. `Id|Timestamp`). |
+| `--output`        | `-o`             | No       | File path to write the generated delta schema. If omitted, output is written to the console. |
 
-##### With data from the console:
+#### Examples
 
-<sub>CMD:</sub>
-```cmd
-type "data.json" | schemathief --stdin -t template.hbs -r json
-```
+##### Output to console:
 
-<sub>PowerShell:</sub>
-```powershell
-Get-Content data.json | schemathief --stdin -t template.hbs -r json
-```
-
-<sub>Bash:</sub>
 ```bash
-cat data.json | schemathief --stdin -t template.hbs -r json
+schemathief delta -a bin/Release/MyApi.dll -c MyApi.Models.Person -b https://schemas.example.com/person.base.json
 ```
 
-In this example:
+##### Output to file with exclusions:
 
-- The input data is coming from the console
-- `template.hbs` is the Handlebars template file.
-- `json` is the parser of input data.
-- the output is redirected to the console.
+```bash
+schemathief delta -a MyApi.dll -c MyApi.Models.Invoice -b base-schema.json -x "CreatedAt|Id" -o invoice.delta.schema.json
+```
 
-Make sure that the template file and source file are correctly formatted and aligned with your data model to produce the desired result.
+##### Notes
+
+- If the generated delta schema is empty (i.e. all properties are already in the base schema or excluded), the CLI will emit:  
+
+  ```
+  No delta schema generated.
+  ```
+
+- The delta is combined with the base using an `allOf` JSON Schema construct.

--- a/README.md
+++ b/README.md
@@ -4,43 +4,34 @@
 
 Schemathief is a lightweight .NET library and CLI tool for generating JSON-Schema delta documents from your CLR types. Whether you need to keep your API schema up-to-date, drive automated data-model documentation, or generate client stubs only for the new fields you’ve added, Schemathief does the heavy lifting:
 
-1. Load & compare
+### Load & compare
 
-Fetches a base schema from a URL or file via a pluggable IBaseSchemaLoader
+* Fetches a base schema from a URL or file via a pluggable IBaseSchemaLoader
+* Reflects over your target assembly to discover all public, read/write properties
+* Allows you to exclude known fields (e.g. legacy or deprecated properties)
 
-Reflects over your target assembly to discover all public, read/write properties
+### Generate delta
 
-Allows you to exclude known fields (e.g. legacy or deprecated properties)
+* Maps .NET types to JSON-Schema types (string, integer, array, object) with full support for nullable, primitive, and complex types
+* Recursively builds nested definitions for child objects and collections
+* Produces a minimal “delta schema” that you can combine with your base via an allOf merge
 
-1. Generate delta
+### CLI & API
 
-Maps .NET types to JSON-Schema types (string, integer, array, object) with full support for nullable, primitive, and complex types
+* A dotnet tool–friendly System.CommandLine implementation (delta verb, intuitive options) ready for CI/CD
+* Dependency-injection–friendly services (IDeltaService, IBaseSchemaLoader) so you can stub or replace behavior in your own apps
+* Fully unit‐tested core (SchemaBuilder, TypeInspector, ClrToJsonTypeMapper, TypeInspectorHelper) and integration‐tested end-to-end
 
-Recursively builds nested definitions for child objects and collections
+### Pack & ship
 
-Produces a minimal “delta schema” that you can combine with your base via an allOf merge
-
-1. CLI & API
-
-A dotnet tool–friendly System.CommandLine implementation (delta verb, intuitive options) ready for CI/CD
-
-Dependency-injection–friendly services (IDeltaService, IBaseSchemaLoader) so you can stub or replace behavior in your own apps
-
-Fully unit‐tested core (SchemaBuilder, TypeInspector, ClrToJsonTypeMapper, TypeInspectorHelper) and integration‐tested end-to-end
-
-1. Pack & ship
-
-Ship your own JSON-Schema artifacts right inside your NuGet package via contentFiles/any/any/schemas so consumers get editor IntelliSense out of the box
-
-Integrates smoothly into existing build pipelines with dotnet pack, GitVersion, or any other automation
+* Ship your own JSON-Schema artifacts right inside your NuGet package via contentFiles/any/any/schemas so consumers get editor IntelliSense out of the box
+* Integrates smoothly into existing build pipelines with dotnet pack, GitVersion, or any other automation
 
 # Why Schemathief?
 
-Zero boilerplate: No more hand-crafting schema diffs by hand or writing reflection glue in every project.
-
-Future-proof: Designed around the JSON-Schema draft-07 spec today, easy to extend for draft-next tomorrow.
-
-Give it a try in your next microservice or data-model repo—keep your schemas in lock-step with your code
+* Zero boilerplate: No more hand-crafting schema diffs by hand or writing reflection glue in every project.
+* Future-proof: Designed around the JSON-Schema draft-07 spec today, easy to extend for draft-next tomorrow.
+* Give it a try in your next microservice or data-model repo—keep your schemas in lock-step with your code
 
 [About][] | [Installing][] | [Quickstart][]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Completely revised the README to focus on Schemathief as a .NET library and CLI tool for generating JSON-Schema delta documents from CLR types.
  - Updated usage instructions, feature descriptions, and examples to reflect the new functionality.
  - Removed outdated references to templating engines and installation methods.
  - Refreshed badges for CI build status and code coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->